### PR TITLE
Add a Dockerfile for Avorion Dedicated Server

### DIFF
--- a/avorion/.gitignore
+++ b/avorion/.gitignore
@@ -1,0 +1,1 @@
+persist

--- a/avorion/Dockerfile
+++ b/avorion/Dockerfile
@@ -1,0 +1,30 @@
+# Avorion Server Dockerfile
+FROM quay.io/jonathanporta/steamcmd
+
+# Install Avorion server files
+RUN ./steamcmd.sh +login anonymous \
+  +force_install_dir /srv \
+  +app_update 565060 validate \
+  +quit
+
+# Copy over the init script for wrapping the executable
+COPY init.sh /srv/
+RUN chmod 755 /srv/init.sh
+
+# Make sure we are in the correct directory
+WORKDIR /srv/
+
+# Opens host and query ports
+EXPOSE 27000/udp
+EXPOSE 27003/udp
+EXPOSE 27020/udp
+EXPOSE 27021/udp
+
+# The UDP+TCP Dockerfile syntax doesn't seem to work.
+EXPOSE 27000/tcp
+EXPOSE 27003/tcp
+EXPOSE 27020/tcp
+EXPOSE 27021/tcp
+
+# Set the server executable as the entrypoint
+ENTRYPOINT ["./init.sh"]

--- a/avorion/Makefile
+++ b/avorion/Makefile
@@ -1,0 +1,27 @@
+REPO = "quay.io/jonathanporta"
+IMAGE = "ogs-avorion"
+PERSIST_DIR = $(shell pwd)/persist
+
+all: build run
+
+build:
+	docker build -t $(REPO)/$(IMAGE) .
+
+# --net="host" is not great, but the virtual networking is not performant.
+run:
+	mkdir -p $(PERSIST_DIR)
+	docker run\
+		--net="host"\
+		-v $(PERSIST_DIR):/root/.avorion/galaxies\
+		-p 27000:27000/udp\
+		-p 27003:27003/udp\
+		-p 27020:27020/udp\
+		-p 27021:27021/udp\
+		-p 27000:27000/tcp\
+		-p 27003:27003/tcp\
+		-p 27020:27020/tcp\
+		-p 27021:27021/tcp\
+		-it $(REPO)/$(IMAGE) -exec ""
+
+push:
+	docker push $(REPO)/$(IMAGE):latest

--- a/avorion/README.md
+++ b/avorion/README.md
@@ -1,0 +1,24 @@
+# Avorion Dedicated Server Dockerfile [![Docker Repository on Quay](https://quay.io/repository/jonathanporta/ogs-avorion/status "Docker Repository on Quay")](https://quay.io/repository/jonathanporta/ogs-avorion)
+Builds a Docker container with the dedicated server files already installed.
+
+# Build
+`make build`
+
+# Usage
+If you're in a hurry you may use `make run`. Otherwise, you probably want to specify some options:
+```
+		docker run\
+			--net="host"\
+			-v $(pwd)/data:/root/.avorion/galaxies
+			-p 27000:27000/udp\
+			-p 27003:27003/udp\
+			-p 27020:27020/udp\
+			-p 27021:27021/udp\
+			-p 27000:27000/tcp\
+			-p 27003:27003/tcp\
+			-p 27020:27020/tcp\
+			-p 27021:27021/tcp\
+			-it $(REPO)/$(IMAGE) -exec ""
+```
+
+NOTE: Using `--net="host"` is not considered secure as the container will now have access to anything listening on the host. Use it only if you know what you are doing. Read more [here](https://docs.docker.com/engine/reference/run/#network-settings).

--- a/avorion/init.sh
+++ b/avorion/init.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+# Wrap the executable
+exec ./server.sh "$@"


### PR DESCRIPTION
A bare minimum Dockerfile for running Avorion Dedicated Server that can
be extended for each "instance" of your Avorion server. This pushes
configuration and customization off to the individual instance without
making any assumptions of the config/rules/type/etc of server to be run.